### PR TITLE
moved the button js all to header, since they are header buttons just…

### DIFF
--- a/client/views/documentation/documentation.js
+++ b/client/views/documentation/documentation.js
@@ -1,9 +1,3 @@
 window.frozenVanilla("documentation", function (vanillaPromise) {
   console.log(vanillaPromise.this + " ran");
-
-  let genButtonRoute = "gen";
-  $("#genbutton-documentation_documentation").on("click", function (e) {
-    let route = this.getAttribute("data-route");
-    window.myState([genButtonRoute, `../${genButtonRoute}`]);
-  });
 });

--- a/client/views/gen/gen.js
+++ b/client/views/gen/gen.js
@@ -3,12 +3,6 @@ window.frozenVanilla("gen", function (vanillaPromise) {
 
   //let button = document.getElementById("create-config");
 
-  let route = "documentation";
-  let button = document.getElementById("docbutton-gen_gen");
-  button.addEventListener("click", function (event) {
-    window.myState([route, `../?burst=${route}`]);
-  });
-
   let subDomClicks = 0;
   $(".addSubDOM").on("click", function (e) {
     subDomClicks++;

--- a/client/views/shared/heroHeader/heroHeader.js
+++ b/client/views/shared/heroHeader/heroHeader.js
@@ -1,9 +1,11 @@
 window.frozenVanilla("heroHeader", function (vanillaPromise) {
   console.log(vanillaPromise.this + " ran");
 
-  let button = document.querySelector("button.headerbutton");
-  button.addEventListener("click", function (event) {
-    let route = event.target.getAttribute("data-route");
-    window.myState([route, `../?burst=${route}`]);
+  let buttons = document.querySelectorAll("button.headerbutton");
+  buttons.forEach((button) => {
+    button.addEventListener("click", function (event) {
+      let route = event.target.getAttribute("data-route");
+      window.myState([route, `../?burst=${route}`]);
+    });
   });
 });

--- a/schemas/documentationConfig.js
+++ b/schemas/documentationConfig.js
@@ -18,7 +18,7 @@ window.frozenVanilla("documentationConfig", function (sharedParts) {
           container: "gen-button_wrapper",
           className: "button round",
           children: `
-          <button class="mygenbutton" data-route="gen">Go to the Config Builder</button>
+          <button class="headerbutton mygenbutton" data-route="gen">Go to the Config Builder</button>
             `,
           eventHandlers: "submit:preventDefault",
         },

--- a/schemas/genConfig.js
+++ b/schemas/genConfig.js
@@ -19,7 +19,7 @@ window.frozenVanilla("genConfig", function (sharedParts) {
           container: "doc-button_wrapper",
           className: "button round",
           children: `
-          <button class="mydocbutton" data-route="documentation">View Documentation</button>
+          <button class="headerbutton mydocbutton" data-route="documentation">View Documentation</button>
             `,
           eventHandlers: "submit:preventDefault",
         },

--- a/schemas/homeviewConfig.js
+++ b/schemas/homeviewConfig.js
@@ -18,7 +18,7 @@ window.frozenVanilla("homeviewConfig", function (sharedParts) {
           id: "docbutton",
           container: "doc-button_wrapper",
           children: `
-          <button class="mydocbutton button round" data-route="gen">View Documentation</button>
+          <button class="headerbutton mydocbutton button round" data-route="gen">View Documentation</button>
             `,
           eventHandlers: "submit:preventDefault",
         },


### PR DESCRIPTION
… repeated elsewhere in the DOM. seems a little more stable, and this corrected the url params so they all include ?burst. This would be how I'd use this in production anyway so might as well test it under the ideal situation for testing. I am noticing some inconsistencies throughout all deploys between render.com live site and local (where local is a bit more stable and accurate to the code)