### PR TITLE
Started adding the config nodes components for the "gen" view landing in "genConfig"

### DIFF
--- a/client/views/gen/components/functionnodeForReference.html
+++ b/client/views/gen/components/functionnodeForReference.html
@@ -1,3 +1,6 @@
+<!-- I wrote the html here for access to HTML helpers in vscode, then copied it into the genConfig.js in components key -->
+<!-- work in progress -->
+
 <h3>View Node</h3>
 <label for="landing">Landing:</label>
 <input type="text" id="landing" name="landing">

--- a/client/views/gen/components/parentnodeForReference.html
+++ b/client/views/gen/components/parentnodeForReference.html
@@ -1,3 +1,6 @@
+<!-- I wrote the html here for access to HTML helpers in vscode, then copied it into the genConfig.js in components key -->
+<!-- work in progress -->
+
 <h3>Parent Node Configuration</h3>
 <small>Name Convention: viewnameConfig.js</small>
 <br /><br />

--- a/client/views/gen/gen.css
+++ b/client/views/gen/gen.css
@@ -1,4 +1,4 @@
-#vanillaFlowCanvas {
+#config-generation-container {
     position: relative;
     display: flex;
     flex-direction: row;
@@ -6,4 +6,28 @@
     width: 100%;
     min-height: 50vh;
     justify-content: center;
+    grid-gap: 5vh;
+}
+.genform{
+    width:40vh;
+    max-width:80vw;
+    background-color: white;
+    box-shadow: 0px 10px 40px 0px rgba(0,0,0,0.05);
+    padding:2vh;
+    border-radius:3vh;
+}
+.genform > form#parentConfigForm input{
+    width:90%;
+}
+.config-canvas{
+    justify-content: center;
+    margin-top:5vh;
+    display: flex;
+    grid-column-gap: 5vh;
+    width: 100%;
+}
+
+.config-title{
+    width: 100%;
+    text-align: center;
 }

--- a/client/views/gen/gen.html
+++ b/client/views/gen/gen.html
@@ -2,4 +2,5 @@
     <h1 class="config-title">Plan and generate your views</h1>
     <div class="doc-button_wrapper"></div>
     <div class="config-canvas"></div>
+    <div id="config-result"></div>
 </div>

--- a/client/views/gen/gen.js
+++ b/client/views/gen/gen.js
@@ -22,29 +22,58 @@ window.frozenVanilla("gen", function (vanillaPromise) {
     nodeConfigBuild();
   });
 
-  //move this to its own functionFile, this gen view might get more complex
+  //move this to its own functionName, this gen view might get more complex
   function nodeConfigBuild() {
+    alert("Config Generated. Check the bottom of this page for the code!");
     // Find the container for the draggable nodes
-    const configCanvas = document.querySelector("#viewbox");
+    const configCanvas = document.querySelector(".config-canvas");
     const nodes = configCanvas.querySelectorAll(".parentnode");
 
-    let configString = "";
-
     // Define a function that generates a configuration object
-    function generateConfig(
-      functionFile,
-      dir,
-      originBurst,
-      htmlPath,
-      cssPath,
-      targetDOM,
-      subDOMObject
-    ) {
+    function generateConfig() {
+      // Get the form values
+      const form = document.querySelector("#parentConfigForm");
+      const functionName = form.querySelector("#functionName").value;
+      const dir = form.querySelector("#directory").value;
+      const originBurst = form.querySelector("#originburst").value;
+      const htmlPath = form.querySelector("#htmlPath").value;
+      const cssPath = form.querySelector("#cssPath").value;
+      const targetDOM = form.querySelector("#targetDOM").value;
+
+      // Get the subDOM values
+      const subDOMTemplate = form.querySelector(".subDOMTemplate");
+      const subDOMHtmlPath = subDOMTemplate.querySelector(
+        "[name='subDOMHtmlPath']"
+      ).value;
+      const subDOMCssPath = subDOMTemplate.querySelector(
+        "[name='subDOMCssPath']"
+      ).value;
+      const subDOMTargetDOM = subDOMTemplate.querySelector(
+        "[name='subDOMTargetDOM']"
+      ).value;
+      const subDOMHtmlAttrId = subDOMTemplate.querySelector(
+        "[name='subDOMHtmlAttrId']"
+      ).value;
+      const subDOMHtmlAttrCssClass = subDOMTemplate.querySelector(
+        "[name='subDOMHtmlAttrCssClass']"
+      ).value;
+
+      // Create the subDOMObject
+      const subDOMObject = {
+        htmlPath: subDOMHtmlPath,
+        cssPath: subDOMCssPath,
+        targetDOM: subDOMTargetDOM,
+        htmlAttrs: {
+          id: subDOMHtmlAttrId,
+          cssClass: subDOMHtmlAttrCssClass,
+        },
+      };
+
       let config = {};
-      config[functionFile] = {
+      config[functionName] = {
         role: "parent",
         dir: dir,
-        functionFile: functionFile,
+        functionName: functionName,
         render: "pause",
         originBurst: originBurst,
         htmlPath: htmlPath,
@@ -55,41 +84,53 @@ window.frozenVanilla("gen", function (vanillaPromise) {
       return config;
     }
 
-    // Use the function in your loop
-    nodes.forEach((node) => {
-      // ... (same as before)
+    let finalConfigs = [];
 
+    nodes.forEach((node) => {
       // Construct the configuration object for each node
-      let nodeConfig = generateConfig(
-        functionFile,
-        dir,
-        originBurst,
-        htmlPath,
-        cssPath,
-        targetDOM,
-        subDOMObject
-      );
+      let nodeConfig = generateConfig();
+      let sharedParts = {};
 
       // Merge nodeConfig with sharedParts and vanillaConfig
       let mergedConfig = { ...nodeConfig, ...sharedParts };
-      let finalConfig = { ...vanillaConfig(functionFile, mergedConfig) };
+      // let finalConfig = { ...vanillaConfig(functionName, mergedConfig) };
 
       // Add the final configuration to the window object
-      window[`${functionFile}Config`] = finalConfig;
+      console.log("functionName:", functionName.value);
+      console.log("mergedConfig:", mergedConfig);
+
+      if (typeof functionName.value === "string" && mergedConfig) {
+        window[`${functionName.value}Config`] = mergedConfig;
+      } else {
+        console.error("Cannot set property on window object");
+      }
+      //window.frozenVanilla(functionName, mergedConfig);
+
+      // Add the final configuration to the finalConfigs array
+      finalConfigs.push(mergedConfig);
     });
 
-    console.log("Generated vanillaBurst Config:", configString);
-
-    // Optional: Copy the config to clipboard
-    navigator.clipboard.writeText(configString).then(
-      function () {
-        alert("Config copied to clipboard!");
-
-        console.log("Copying to clipboard was successful!");
-      },
-      function (err) {
-        console.error("Could not copy text: ", err);
+    const configResultDiv = document.getElementById("config-result");
+    if (configResultDiv) {
+      // Convert the finalConfigs array to a string
+      const configString = JSON.stringify(finalConfigs, null, 2); // Beautify the JSON string
+      if (configResultDiv) {
+        // Convert the finalConfigs array to a string
+        const configString = JSON.stringify(finalConfigs, null, 2); // Beautify the JSON string
+        configResultDiv.innerHTML = `<pre>${configString}</pre>`;
       }
-    );
+    }
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(configString).then(
+        function () {
+          alert("Config copied to clipboard!");
+          console.log("Copying to clipboard was successful!");
+        },
+        function (err) {
+          console.error("Could not copy text: ", err);
+        }
+      );
+    } else {
+    }
   }
 });

--- a/schemas/genConfig.js
+++ b/schemas/genConfig.js
@@ -30,9 +30,73 @@ window.frozenVanilla("genConfig", function (sharedParts) {
           container: "config-canvas",
           className: "parentnode genform",
           children: `
-              <div id="yo"><input type='text' name='functionName' placeholder='Function Name' />
-              <textarea name='functionBody' placeholder='Function Body'></textarea>
-              <input type='submit' value='Create Function' /></div>
+          <h3>Parent Node Configuration</h3>
+          <small>Name Convention: viewnameConfig.js</small>
+          <br /><br />
+          <form id="parentConfigForm">
+              <div class="fields">
+          
+                  <input type="hidden" id="role" name="role" value="parent"><br />
+          
+                  <label for="functionName">View Name:</label><br />
+                  <input type="text" id="functionName" name="functionName" placeholder="e.g., myFunction"><br />
+          
+                  <label for="directory">Directory:</label><br />
+                  <input type="text" id="directory" name="dir" placeholder="e.g., client/views/myFunction/"><br />
+          
+                  <label for="renderMode">Render Mode: 'pause' </label><br />
+                  <small>Change manually to 'burst' if needed</small>
+                  <br /> <br />
+          
+                  <label for="originburst">Origin Burst:</label><br />
+                  <input type="text" id="originburst" name="originburst" placeholder="e.g., a custom object"><br />
+          
+                  <label for="htmlPath">HTML Path:</label><br />
+                  <input type="text" id="htmlPath" name="htmlPath"
+                      placeholder="e.g., myFunction.html (relative to Directory above)"><br />
+          
+                  <label for="cssPath">CSS Path:</label><br />
+                  <input type="text" id="cssPath" name="cssPath"
+                      placeholder="e.g., myFunction.css (relative to Directory above)"><br />
+          
+                  <label for="targetDOM">Target DOM:</label><br />
+                  <input type="text" id="targetDOM" name="targetDOM" placeholder="e.g., someDOMId"><br /><br />
+          
+          
+                  <fieldset class="subDOMTemplate" style="display: none">
+                      <legend>Sub DOM Configuration</legend>
+                      <div class=" subDOMFieldsContainer" ">
+                              <label for=" htmlPath">HTML Path:</label><br />
+                          <input type="text" name="subDOMHtmlPath" placeholder="e.g., path"><br />
+          
+                          <label for="cssPath">CSS Path:</label><br />
+                          <input type="text" name="subDOMCssPath" placeholder="e.g., path"><br />
+          
+                          <label for="targetDOM">Target DOM:</label><br />
+                          <input type="text" name="subDOMTargetDOM" placeholder="e.g., id"><br />
+          
+                          <label for="htmlAttrs">HTML Attributes:</label><br />
+                          <fieldset id="subDOMTemplate">
+                              <!-- existing fields... -->
+          
+                              <h3>HTML Attributes:</h3>
+          
+                              <label for="id">ID:</label><br />
+                              <input type="text" name="subDOMHtmlAttrId"><br />
+          
+                              <label for="cssclass">CSS Class:</label><br />
+                              <input type="text" name="subDOMHtmlAttrCssClass"><br />
+                          </fieldset>
+                      </div>
+                  </fieldset>
+                  <label for="subDOM">Sub DOM:</label><br />
+                  <button id="subDOM" class="addSubDOM" name="subDOM">Add Sub DOM</button><br /><br />
+          
+          
+              </div>
+              <button id="create-config">Create Config</button>
+          
+          </form>
             `,
           eventHandlers: "submit:preventDefault",
         },
@@ -41,9 +105,21 @@ window.frozenVanilla("genConfig", function (sharedParts) {
           parent: true,
           id: "functionnode",
           container: "config-canvas",
-          className: "viewnode",
+          className: "genform",
           children: `
-              <div id="yo"> say hello </div>
+          <h3>View Node</h3>
+          <label for="landing">Landing:</label>
+          <input type="text" id="landing" name="landing">
+          <div class="scripts">
+              <h4>Scripts</h4>
+              <div class="script-inputs">
+                  <label for="script">Script:</label>
+                  <input type="text" id="script" name="script[]">
+              </div>
+              <button id="add-script">Add Script</button>
+          </div>
+          <label for="preloader">Preloader:</label>
+          <input type="text" id="preloader" name="preloader">
           `,
         },
       },

--- a/style.css
+++ b/style.css
@@ -38,7 +38,7 @@
      address,
      big,
      cite,
-     code,
+     /* code, */
      del,
      dfn,
      em,
@@ -209,7 +209,7 @@
         margin: 2em 0;
     }
     
-    code {
+    code, pre {
         background-color: #032f3f; /* darkest color */
         color: #fdfdf1; /* lightest color */
         padding: 4px 6px;

--- a/vanillaBurstScripts/vanillaDOM/processors/htmlFileLoader.js
+++ b/vanillaBurstScripts/vanillaDOM/processors/htmlFileLoader.js
@@ -78,6 +78,12 @@ window.frozenVanilla(
           img.setAttribute("nonce", nonceString);
         }
 
+        let formElements = doc.getElementsByTagName("form");
+        for (let form of formElements) {
+          let nonceString = window.nonceBack();
+          form.setAttribute("nonce", nonceString);
+        }
+
         // Ensure that the HTML content is correctly extracted
         contentToUse = doc.documentElement.outerHTML;
         console.log(

--- a/vanillaBurstScripts/vanillaDOM/processors/sanitizeVanillaDOM.js
+++ b/vanillaBurstScripts/vanillaDOM/processors/sanitizeVanillaDOM.js
@@ -1,7 +1,7 @@
 window.frozenVanilla("sanitizeVanillaDOM", function (htmlString, functionFile) {
   try {
     const config = {
-      ADD_TAGS: { "vanilla-element": ["name"], script: {} },
+      ADD_TAGS: { form: {}, "vanilla-element": ["name"], script: {} },
       USE_PROFILES: { html: true },
     };
 


### PR DESCRIPTION
Started adding the config nodes components for the "gen" view landing in "genConfig" and some styling. The config generation does work, but it's not 100% accurate to latest version yet.
This is not necessarily work for the development of the framework but rather putting it in practice! And it's working as expected so that's good.
Also I added "form" tag to DOMPurify in sanitizeVanillaDOM. It throws a CSP rejection for styles but not 100% sure if that's my HTML including CSS or if it's reacting to the FORM tag still. Regardless for the time being the form is rendering, and it is allowing me to use the framework. Will tighten the requirements on that standard. 
Optional consideration: a custom sanitizer which could be configured based on the config's components. ie; allowTags:["form","image","code",...etc, ...etc]