### PR TITLE
disabled cache false for canvasresults, since it's supposed to showca…

### DIFF
--- a/schemas/genConfig.js
+++ b/schemas/genConfig.js
@@ -123,7 +123,7 @@ window.frozenVanilla("genConfig", function (sharedParts) {
           `,
         },
         canvasresult: {
-          cache: false,
+          // cache: false,
           parent: true,
           id: "configresult",
           container: "config-canvas",


### PR DESCRIPTION
…se caching, where the weather showcases non cache already, also good idea to keep generated code cached just incase.